### PR TITLE
Update src/org/envaya/sms/IncomingMessage.java

### DIFF
--- a/src/org/envaya/sms/IncomingMessage.java
+++ b/src/org/envaya/sms/IncomingMessage.java
@@ -71,7 +71,7 @@ public abstract class IncomingMessage extends QueuedMessage {
             }
         }
         
-        return fromDigits >= 7;
+        return fromDigits >= 0;
     }
     
     public String getFrom()


### PR DESCRIPTION
The 7 digits restriction on incoming SMS sender identity doesn't make good sense here.
